### PR TITLE
Fix for 0.4.2.2

### DIFF
--- a/PoseHitboxes/ClassPH.cs
+++ b/PoseHitboxes/ClassPH.cs
@@ -1,9 +1,10 @@
-﻿using MelonLoader;
-using Il2CppRUMBLE.Tutorial.MoveLearning;
+﻿using Il2CppRUMBLE.Tutorial.MoveLearning;
+using MelonLoader;
 using RumbleModdingAPI;
+using System.Collections;
+
 //using static RumbleModdingAPI.Calls;
 using UnityEngine;
-using System.Linq.Expressions;
 //using static RUMBLE.Players.Subsystems.PlayerVR;
 //using static RumbleModdingAPI.Calls.GameObjects.Gym.Logic.HeinhouserProducts.MoveLearning.MoveLearnSelector;
 //using static RumbleModdingAPI.Calls.GameObjects.Gym.Logic.HeinhouserProducts.MoveLearning;
@@ -47,6 +48,7 @@ namespace PoseHitboxes
         Color red1 = new Color(1.0f, 0.0f, 0.0f, 0.1f);
         Color green1 = new Color(0.0f, 1.0f, 0.0f, 0.1f);
         Color blue1 = new Color(0.0f, 0.0f, 1.0f, 0.1f);
+        object coroutine = null;
 
         //creates a child set of WFParent with a given material and color in the shape of a 1x1x1 wireframe cube made of primative cubes. 
         private void BuildWireframeBox(GameObject WFParent, Material WFMat, Color WFColor)
@@ -109,10 +111,9 @@ namespace PoseHitboxes
                         {
                             //MelonLogger.Msg("loading items");
                             
-
-                            poseGhost = Calls.GameObjects.Gym.Logic.HeinhouserProducts.MoveLearning.GetGameObject().GetComponentInChildren<PoseGhost>();//<PoseGhost>();//GameObject.Find("--------------LOGIC--------------/Heinhouser products/MoveLearning/Ghost").GetComponent<PoseGhost>();
-                            ghosty = poseGhost.transform.GetChild(0).GetChild(1).GetComponent<Renderer>().material;
-                            redy = Calls.GameObjects.Gym.Scene.GymProduction.MainStaticGroup.GymArena.GetGameObject().transform.GetChild(0).GetComponent<Renderer>().material;
+                            poseGhost = Calls.GameObjects.Gym.LOGIC.Heinhouserproducts.MoveLearning.GetGameObject().GetComponentInChildren<PoseGhost>();//<PoseGhost>();//GameObject.Find("--------------LOGIC--------------/Heinhouser products/MoveLearning/Ghost").GetComponent<PoseGhost>();
+                            ghosty = poseGhost.bodyRenderer.transform.parent.GetChild(1).GetComponent<Renderer>().material;
+                            redy = Calls.GameObjects.Gym.SCENE.GymProduction.Mainstaticgroup.Gymarena.GetGameObject().transform.GetChild(0).GetComponent<Renderer>().material;
                             ////HBRef = GameObject.Find("Player Controller(Clone)/Visuals/RIG");///Bone_Shoulderblade_L/Bone_Shoulder_L/Bone_Lowerarm_L/Bone_Hand_L");
                             ////HBRefHead = GameObject.Find("Player Controller(Clone)/Visuals/RIG/Bone_Pelvis/Bone_Spine/Bone_Chest/Bone_Neck/Bone_Head");
                             LHandRef = GameObject.Find("Player Controller(Clone)/Visuals/Skelington/Bone_Pelvis/Bone_Spine_A/Bone_Chest/Bone_Shoulderblade_L/Bone_Shoulder_L/Bone_Lowerarm_L/Bone_HandAlpha_L");
@@ -134,19 +135,19 @@ namespace PoseHitboxes
                 //if pose switched 
                 try
                 {
-                    if (currentPoseName != poseGhost.showCurrentPoseData.name)
+                    if (currentPoseName != poseGhost.CurrentPoseSet.configurations[poseGhost.currentVisualPoseIndex].Pose.name)
                     {
                         //MelonLogger.Msg("chkpt 2");
-                        if (poseGhost.poseGhostVisuals.transform.GetChild(0).childCount > 0)
+                        if (poseGhost.bodyRenderer.transform.parent.GetChild(0).childCount > 0)
                         {
                             //MelonLogger.Msg("chkpt 3");
                             // MelonLogger.Msg("Destroying Existing");
-                            while (poseGhost.poseGhostVisuals.transform.GetChild(0).childCount > 0 || poseGhost.poseGhostVisuals.transform.GetChild(1).childCount > 0)
+                            while (poseGhost.bodyRenderer.transform.parent.GetChild(0).childCount > 0 || poseGhost.bodyRenderer.transform.parent.GetChild(1).childCount > 0)
                             {
                                 try
                                 {
-                                    GameObject.DestroyImmediate(poseGhost.poseGhostVisuals.transform.GetChild(0).GetChild(0).gameObject);
-                                    GameObject.DestroyImmediate(poseGhost.poseGhostVisuals.transform.GetChild(1).GetChild(0).gameObject);
+                                    GameObject.DestroyImmediate(poseGhost.bodyRenderer.transform.parent.GetChild(0).GetChild(0).gameObject);
+                                    GameObject.DestroyImmediate(poseGhost.bodyRenderer.transform.parent.GetChild(1).GetChild(0).gameObject);
                                     GameObject.DestroyImmediate(LRotate.gameObject);
                                     GameObject.DestroyImmediate(RRotate.gameObject);
                                     //MelonLogger.Msg("objects destroyed");
@@ -155,161 +156,11 @@ namespace PoseHitboxes
                                 { return; }
                             }
                         }
-                        // MelonLogger.Msg("Creating Primitives");
-
-                        //LCube = GameObject.CreatePrimitive(PrimitiveType.Cube);
-                        //RCube = GameObject.CreatePrimitive(PrimitiveType.Cube);
-                        //MelonLogger.Msg("cubes start0");
-                        GameObject LCube = GameObject.CreatePrimitive(PrimitiveType.Cube);
-                        GameObject RCube = GameObject.CreatePrimitive(PrimitiveType.Cube);
-                        //MelonLogger.Msg("cubes start1");
-                        LCube.transform.parent = poseGhost.transform.GetChild(0).GetChild(0);
-                        RCube.transform.parent = poseGhost.transform.GetChild(0).GetChild(1);
-                        //MelonLogger.Msg("cubes start2");
-                        LCube.transform.position = poseGhost.leftHand.position;//showCurrentPoseData.leftControllerCondition.DesiredPose.position;
-                        RCube.transform.position = poseGhost.rightHand.position;
-                        //MelonLogger.Msg("cubes made");
-
-                        BuildWireframeBox(LCube.gameObject, redy, black8);
-                        BuildWireframeBox(RCube.gameObject, redy, black8);
-                        //MelonLogger.Msg("wires made");
-                        ////LCube.transform.parent = HBRef.transform; // poseGhost.transform.GetChild(0).GetChild(0);
-                        ////RCube.transform.parent = HBRef.transform; //poseGhost.transform.GetChild(0).GetChild(1);
-                        ////LCube.transform.localPosition = poseGhost.leftHand.localPosition + new Vector3(0.5f, 0.5f, 0f);
-                        ////RCube.transform.localPosition = poseGhost.rightHand.localPosition + new Vector3(0.5f, 0.5f, 0f);
-                        ////LCube.transform.RotateAround(HBRef.transform.position, Vector3.forward, 180f); //flip it over, not sure why it is upside down
-                        ////RCube.transform.RotateAround(HBRef.transform.position, Vector3.forward, 180f); //flip it over, not sure why it is upside down
-
-                        LCube.GetComponent<Renderer>().enabled = false;
-                        RCube.GetComponent<Renderer>().enabled = false;
-                        poseGhost.transform.GetChild(0).GetChild(0).GetComponent<Renderer>().material = redy;
-                        poseGhost.transform.GetChild(0).GetChild(1).GetComponent<Renderer>().material = redy;
-                        currentPoseName = poseGhost.showCurrentPoseData.name;
-
-
-                        //setup gyro objects and details
-                        LRotate = GameObject.CreatePrimitive(PrimitiveType.Cube);
-                        RRotate = GameObject.CreatePrimitive(PrimitiveType.Cube);
-                        GameObject LYBar = GameObject.CreatePrimitive(PrimitiveType.Cube);
-                        GameObject LZBar = GameObject.CreatePrimitive(PrimitiveType.Cube);
-                        GameObject RYBar = GameObject.CreatePrimitive(PrimitiveType.Cube);
-                        GameObject RZBar = GameObject.CreatePrimitive(PrimitiveType.Cube);
-
-                        LRotate.transform.parent = poseGhost.transform.GetChild(0).GetChild(0);
-                        RRotate.transform.parent = poseGhost.transform.GetChild(0).GetChild(1);
-
-                        LRotate.GetComponent<Renderer>().material = redy;
-                        RRotate.GetComponent<Renderer>().material = redy;
-                        LRotate.transform.localScale = new Vector3(0.003f, 0.003f, 0.003f);
-                        RRotate.transform.localScale = new Vector3(0.003f, 0.003f, 0.003f);
-
-                        LYBar.transform.parent = LRotate.transform;
-                        LZBar.transform.parent = LRotate.transform;
-                        RYBar.transform.parent = RRotate.transform;
-                        RZBar.transform.parent = RRotate.transform;
-
-                        LYBar.transform.localScale = new Vector3(1f, 25f, 1f);
-                        LZBar.transform.localScale = new Vector3(1f, 1f, 25f);
-                        RYBar.transform.localScale = new Vector3(1f, 25f, 1f);
-                        RZBar.transform.localScale = new Vector3(1f, 1f, 25f);
-
-                        LYBar.GetComponent<Renderer>().material.shader = Shader.Find("Universal Render Pipeline/Lit");
-                        LZBar.GetComponent<Renderer>().material.shader = Shader.Find("Universal Render Pipeline/Lit");
-                        RYBar.GetComponent<Renderer>().material.shader = Shader.Find("Universal Render Pipeline/Lit");
-                        RZBar.GetComponent<Renderer>().material.shader = Shader.Find("Universal Render Pipeline/Lit");
-
-                        LYBar.GetComponent<Renderer>().material.color = green8;
-                        LZBar.GetComponent<Renderer>().material.color = blue8;
-                        RYBar.GetComponent<Renderer>().material.color = green8;
-                        RZBar.GetComponent<Renderer>().material.color = blue8;
-
-                        LRotate.transform.position = poseGhost.leftHand.position + new Vector3(-1.0f, 0.00f, -1.0f);
-                        RRotate.transform.position = poseGhost.rightHand.position + new Vector3(-1.0f, 0.00f, -1.0f);
-                        //MelonLogger.Msg("gyros made");
-                        //generate reference cylinders
-
-                        LRotateLimit = GameObject.CreatePrimitive(PrimitiveType.Sphere);
-                        RRotateLimit = GameObject.CreatePrimitive(PrimitiveType.Sphere);
-                        GameObject LYBarLimit = GameObject.CreatePrimitive(PrimitiveType.Cylinder);
-                        GameObject LZBarLimit = GameObject.CreatePrimitive(PrimitiveType.Cylinder);
-                        GameObject RYBarLimit = GameObject.CreatePrimitive(PrimitiveType.Cylinder);
-                        GameObject RZBarLimit = GameObject.CreatePrimitive(PrimitiveType.Cylinder);
-
-                        //calculate trig for degree limits
-
-
-                        if (poseGhost.leftHand.rotation.eulerAngles.x == poseGhost.showCurrentPoseData.leftControllerCondition.DesiredPose.rotation.eulerAngles.x) // if the hands are not mirrored, use the normal map
+                        if (coroutine != null)
                         {
-                            LThresh = poseGhost.showCurrentPoseData.LeftControllerCondition.RotationTreshold;
-                            RThresh = poseGhost.showCurrentPoseData.RightControllerCondition.RotationTreshold;
-                            LCube.transform.localScale = new Vector3(poseGhost.showCurrentPoseData.leftControllerCondition.PositionTreshold, poseGhost.showCurrentPoseData.leftControllerCondition.PositionTreshold, poseGhost.showCurrentPoseData.leftControllerCondition.PositionTreshold);
-                            RCube.transform.localScale = new Vector3(poseGhost.showCurrentPoseData.RightControllerCondition.PositionTreshold, poseGhost.showCurrentPoseData.RightControllerCondition.PositionTreshold, poseGhost.showCurrentPoseData.RightControllerCondition.PositionTreshold);
-
-                            // MelonLogger.Msg("right hand mode");
+                            MelonCoroutines.Stop(coroutine);
                         }
-                        else // they need to be swapped
-                        {
-                            RThresh = poseGhost.showCurrentPoseData.LeftControllerCondition.RotationTreshold;
-                            LThresh = poseGhost.showCurrentPoseData.RightControllerCondition.RotationTreshold;
-                            RCube.transform.localScale = new Vector3(poseGhost.showCurrentPoseData.leftControllerCondition.PositionTreshold, poseGhost.showCurrentPoseData.leftControllerCondition.PositionTreshold, poseGhost.showCurrentPoseData.leftControllerCondition.PositionTreshold);
-                            LCube.transform.localScale = new Vector3(poseGhost.showCurrentPoseData.RightControllerCondition.PositionTreshold, poseGhost.showCurrentPoseData.RightControllerCondition.PositionTreshold, poseGhost.showCurrentPoseData.RightControllerCondition.PositionTreshold);
-
-                            //MelonLogger.Msg("left hand mode");
-                        }
-
-                        float LRotationLimit = ((1 - LThresh) * 3.14159f);
-                        float RRotationLimit = ((1 - RThresh) * 3.14159f);
-
-                        LRotateLimit.transform.parent = poseGhost.transform.GetChild(0).GetChild(0);
-                        RRotateLimit.transform.parent = poseGhost.transform.GetChild(0).GetChild(1);
-
-                        LRotateLimit.GetComponent<Renderer>().material = redy;
-                        RRotateLimit.GetComponent<Renderer>().material = redy;
-                        LRotateLimit.transform.localScale = new Vector3(0.03f * LThresh, 0.03f * LThresh, 0.03f * LThresh);
-                        RRotateLimit.transform.localScale = new Vector3(0.03f * RThresh, 0.03f * RThresh, 0.03f * RThresh);
-
-                        LYBarLimit.transform.parent = LRotateLimit.transform;
-                        LZBarLimit.transform.parent = LRotateLimit.transform;
-                        RYBarLimit.transform.parent = RRotateLimit.transform;
-                        RZBarLimit.transform.parent = RRotateLimit.transform;
-
-                        LYBarLimit.transform.localScale = new Vector3(LRotationLimit, 0.6f, LRotationLimit);
-                        LZBarLimit.transform.localScale = new Vector3(LRotationLimit, 0.6f, LRotationLimit);
-                        RYBarLimit.transform.localScale = new Vector3(RRotationLimit, 0.6f, RRotationLimit);
-                        RZBarLimit.transform.localScale = new Vector3(RRotationLimit, 0.6f, RRotationLimit);
-
-                        LYBarLimit.transform.Rotate(new Vector3(0f, 90f, 0f), Space.Self);
-                        LZBarLimit.transform.Rotate(new Vector3(90f, 0f, 0f), Space.Self);
-                        RYBarLimit.transform.Rotate(new Vector3(0f, 90f, 0f), Space.Self);
-                        RZBarLimit.transform.Rotate(new Vector3(90f, 0f, 0f), Space.Self);
-
-                        LYBarLimit.GetComponent<Renderer>().material.shader = Shader.Find("Universal Render Pipeline/Lit");
-                        LZBarLimit.GetComponent<Renderer>().material.shader = Shader.Find("Universal Render Pipeline/Lit");
-                        RYBarLimit.GetComponent<Renderer>().material.shader = Shader.Find("Universal Render Pipeline/Lit");
-                        RZBarLimit.GetComponent<Renderer>().material.shader = Shader.Find("Universal Render Pipeline/Lit");
-
-                        LYBarLimit.GetComponent<Renderer>().material.color = green1;
-                        LZBarLimit.GetComponent<Renderer>().material.color = blue1;
-                        RYBarLimit.GetComponent<Renderer>().material.color = green1;
-                        RZBarLimit.GetComponent<Renderer>().material.color = blue1;
-
-                        LRotateLimit.transform.position = poseGhost.leftHand.position + new Vector3(-0.3f, 0.15f, -0.3f);
-                        RRotateLimit.transform.position = poseGhost.rightHand.position + new Vector3(-0.3f, 0.15f, -0.3f);
-                        LRotate.transform.position = poseGhost.leftHand.position + new Vector3(-0.3f, 0.15f, -0.3f);
-                        RRotate.transform.position = poseGhost.rightHand.position + new Vector3(-0.3f, 0.15f, -0.3f);
-                        if (poseGhost.leftHand.rotation.eulerAngles.x == poseGhost.showCurrentPoseData.leftControllerCondition.DesiredPose.rotation.eulerAngles.x) // if the hands are not mirrored, use the normal map
-                        {
-                            LCube.transform.localRotation = poseGhost.showCurrentPoseData.leftControllerCondition.DesiredPose.rotation;
-                            RCube.transform.localRotation = poseGhost.showCurrentPoseData.rightControllerCondition.DesiredPose.rotation;
-                        }
-                        else // they need to be swapped
-                        {
-                            RCube.transform.localRotation = poseGhost.showCurrentPoseData.leftControllerCondition.DesiredPose.rotation;
-                            LCube.transform.localRotation = poseGhost.showCurrentPoseData.rightControllerCondition.DesiredPose.rotation;
-                        }
-                        LRotateLimit.transform.rotation = LCube.transform.rotation;
-                        RRotateLimit.transform.rotation = RCube.transform.rotation;
-                        //MelonLogger.Msg("gyros done");
+                        coroutine = MelonCoroutines.Start(CreateHitboxes());
                     }
                 }
 
@@ -336,6 +187,167 @@ namespace PoseHitboxes
                 }
             }
             catch { return; }
+        }
+
+        IEnumerator CreateHitboxes()
+        {
+
+            currentPoseName = poseGhost.CurrentPoseSet.configurations[poseGhost.currentVisualPoseIndex].Pose.name;
+            while (poseGhost.currentPoseLerp < 0.5f) { yield return null; }
+
+            //LCube = GameObject.CreatePrimitive(PrimitiveType.Cube);
+            //RCube = GameObject.CreatePrimitive(PrimitiveType.Cube);
+            //MelonLogger.Msg("cubes start0");
+            GameObject LCube = GameObject.CreatePrimitive(PrimitiveType.Cube);
+            GameObject RCube = GameObject.CreatePrimitive(PrimitiveType.Cube);
+            //MelonLogger.Msg("cubes start1");
+            LCube.transform.parent = poseGhost.bodyRenderer.transform.parent.GetChild(0);
+            RCube.transform.parent = poseGhost.bodyRenderer.transform.parent.GetChild(1);
+            //MelonLogger.Msg("cubes start2");
+            LCube.transform.position = poseGhost.leftHand.position;//showCurrentPoseData.leftControllerCondition.DesiredPose.position;
+            RCube.transform.position = poseGhost.rightHand.position;
+            //MelonLogger.Msg("cubes made");
+
+            BuildWireframeBox(LCube.gameObject, redy, black8);
+            BuildWireframeBox(RCube.gameObject, redy, black8);
+            //MelonLogger.Msg("wires made");
+            ////LCube.transform.parent = HBRef.transform; // poseGhost.transform.GetChild(0).GetChild(0);
+            ////RCube.transform.parent = HBRef.transform; //poseGhost.transform.GetChild(0).GetChild(1);
+            ////LCube.transform.localPosition = poseGhost.leftHand.localPosition + new Vector3(0.5f, 0.5f, 0f);
+            ////RCube.transform.localPosition = poseGhost.rightHand.localPosition + new Vector3(0.5f, 0.5f, 0f);
+            ////LCube.transform.RotateAround(HBRef.transform.position, Vector3.forward, 180f); //flip it over, not sure why it is upside down
+            ////RCube.transform.RotateAround(HBRef.transform.position, Vector3.forward, 180f); //flip it over, not sure why it is upside down
+
+            LCube.GetComponent<Renderer>().enabled = false;
+            RCube.GetComponent<Renderer>().enabled = false;
+            poseGhost.bodyRenderer.transform.parent.GetChild(0).GetComponent<Renderer>().material = redy;
+            poseGhost.bodyRenderer.transform.parent.GetChild(1).GetComponent<Renderer>().material = redy;
+
+
+            //setup gyro objects and details
+            LRotate = GameObject.CreatePrimitive(PrimitiveType.Cube);
+            RRotate = GameObject.CreatePrimitive(PrimitiveType.Cube);
+            GameObject LYBar = GameObject.CreatePrimitive(PrimitiveType.Cube);
+            GameObject LZBar = GameObject.CreatePrimitive(PrimitiveType.Cube);
+            GameObject RYBar = GameObject.CreatePrimitive(PrimitiveType.Cube);
+            GameObject RZBar = GameObject.CreatePrimitive(PrimitiveType.Cube);
+
+            LRotate.transform.parent = poseGhost.bodyRenderer.transform.parent.GetChild(0);
+            RRotate.transform.parent = poseGhost.bodyRenderer.transform.parent.GetChild(1);
+
+            LRotate.GetComponent<Renderer>().material = redy;
+            RRotate.GetComponent<Renderer>().material = redy;
+            LRotate.transform.localScale = new Vector3(0.003f, 0.003f, 0.003f);
+            RRotate.transform.localScale = new Vector3(0.003f, 0.003f, 0.003f);
+
+            LYBar.transform.parent = LRotate.transform;
+            LZBar.transform.parent = LRotate.transform;
+            RYBar.transform.parent = RRotate.transform;
+            RZBar.transform.parent = RRotate.transform;
+
+            LYBar.transform.localScale = new Vector3(1f, 25f, 1f);
+            LZBar.transform.localScale = new Vector3(1f, 1f, 25f);
+            RYBar.transform.localScale = new Vector3(1f, 25f, 1f);
+            RZBar.transform.localScale = new Vector3(1f, 1f, 25f);
+
+            LYBar.GetComponent<Renderer>().material.shader = Shader.Find("Universal Render Pipeline/Lit");
+            LZBar.GetComponent<Renderer>().material.shader = Shader.Find("Universal Render Pipeline/Lit");
+            RYBar.GetComponent<Renderer>().material.shader = Shader.Find("Universal Render Pipeline/Lit");
+            RZBar.GetComponent<Renderer>().material.shader = Shader.Find("Universal Render Pipeline/Lit");
+
+            LYBar.GetComponent<Renderer>().material.color = green8;
+            LZBar.GetComponent<Renderer>().material.color = blue8;
+            RYBar.GetComponent<Renderer>().material.color = green8;
+            RZBar.GetComponent<Renderer>().material.color = blue8;
+
+            LRotate.transform.position = poseGhost.leftHand.position + new Vector3(-1.0f, 0.00f, -1.0f);
+            RRotate.transform.position = poseGhost.rightHand.position + new Vector3(-1.0f, 0.00f, -1.0f);
+            //MelonLogger.Msg("gyros made");
+            //generate reference cylinders
+
+            LRotateLimit = GameObject.CreatePrimitive(PrimitiveType.Sphere);
+            RRotateLimit = GameObject.CreatePrimitive(PrimitiveType.Sphere);
+            GameObject LYBarLimit = GameObject.CreatePrimitive(PrimitiveType.Cylinder);
+            GameObject LZBarLimit = GameObject.CreatePrimitive(PrimitiveType.Cylinder);
+            GameObject RYBarLimit = GameObject.CreatePrimitive(PrimitiveType.Cylinder);
+            GameObject RZBarLimit = GameObject.CreatePrimitive(PrimitiveType.Cylinder);
+
+            //calculate trig for degree limits
+
+
+            if (poseGhost.leftHand.rotation.eulerAngles.x == poseGhost.CurrentPoseSet.configurations[poseGhost.currentVisualPoseIndex].Pose.leftControllerCondition.DesiredPose.rotation.eulerAngles.x) // if the hands are not mirrored, use the normal map
+            {
+                LThresh = poseGhost.CurrentPoseSet.configurations[poseGhost.currentVisualPoseIndex].Pose.LeftControllerCondition.RotationTreshold;
+                RThresh = poseGhost.CurrentPoseSet.configurations[poseGhost.currentVisualPoseIndex].Pose.RightControllerCondition.RotationTreshold;
+                LCube.transform.localScale = new Vector3(poseGhost.CurrentPoseSet.configurations[poseGhost.currentVisualPoseIndex].Pose.leftControllerCondition.PositionTreshold, poseGhost.CurrentPoseSet.configurations[poseGhost.currentVisualPoseIndex].Pose.leftControllerCondition.PositionTreshold, poseGhost.CurrentPoseSet.configurations[poseGhost.currentVisualPoseIndex].Pose.leftControllerCondition.PositionTreshold);
+                RCube.transform.localScale = new Vector3(poseGhost.CurrentPoseSet.configurations[poseGhost.currentVisualPoseIndex].Pose.RightControllerCondition.PositionTreshold, poseGhost.CurrentPoseSet.configurations[poseGhost.currentVisualPoseIndex].Pose.RightControllerCondition.PositionTreshold, poseGhost.CurrentPoseSet.configurations[poseGhost.currentVisualPoseIndex].Pose.RightControllerCondition.PositionTreshold);
+
+                // MelonLogger.Msg("right hand mode");
+            }
+            else // they need to be swapped
+            {
+                RThresh = poseGhost.CurrentPoseSet.configurations[poseGhost.currentVisualPoseIndex].Pose.LeftControllerCondition.RotationTreshold;
+                LThresh = poseGhost.CurrentPoseSet.configurations[poseGhost.currentVisualPoseIndex].Pose.RightControllerCondition.RotationTreshold;
+                RCube.transform.localScale = new Vector3(poseGhost.CurrentPoseSet.configurations[poseGhost.currentVisualPoseIndex].Pose.leftControllerCondition.PositionTreshold, poseGhost.CurrentPoseSet.configurations[poseGhost.currentVisualPoseIndex].Pose.leftControllerCondition.PositionTreshold, poseGhost.CurrentPoseSet.configurations[poseGhost.currentVisualPoseIndex].Pose.leftControllerCondition.PositionTreshold);
+                LCube.transform.localScale = new Vector3(poseGhost.CurrentPoseSet.configurations[poseGhost.currentVisualPoseIndex].Pose.RightControllerCondition.PositionTreshold, poseGhost.CurrentPoseSet.configurations[poseGhost.currentVisualPoseIndex].Pose.RightControllerCondition.PositionTreshold, poseGhost.CurrentPoseSet.configurations[poseGhost.currentVisualPoseIndex].Pose.RightControllerCondition.PositionTreshold);
+
+                //MelonLogger.Msg("left hand mode");
+            }
+
+            float LRotationLimit = ((1 - LThresh) * 3.14159f);
+            float RRotationLimit = ((1 - RThresh) * 3.14159f);
+
+            LRotateLimit.transform.parent = poseGhost.bodyRenderer.transform.parent.GetChild(0);
+            RRotateLimit.transform.parent = poseGhost.bodyRenderer.transform.parent.GetChild(1);
+
+            LRotateLimit.GetComponent<Renderer>().material = redy;
+            RRotateLimit.GetComponent<Renderer>().material = redy;
+            LRotateLimit.transform.localScale = new Vector3(0.03f * LThresh, 0.03f * LThresh, 0.03f * LThresh);
+            RRotateLimit.transform.localScale = new Vector3(0.03f * RThresh, 0.03f * RThresh, 0.03f * RThresh);
+
+            LYBarLimit.transform.parent = LRotateLimit.transform;
+            LZBarLimit.transform.parent = LRotateLimit.transform;
+            RYBarLimit.transform.parent = RRotateLimit.transform;
+            RZBarLimit.transform.parent = RRotateLimit.transform;
+
+            LYBarLimit.transform.localScale = new Vector3(LRotationLimit, 0.6f, LRotationLimit);
+            LZBarLimit.transform.localScale = new Vector3(LRotationLimit, 0.6f, LRotationLimit);
+            RYBarLimit.transform.localScale = new Vector3(RRotationLimit, 0.6f, RRotationLimit);
+            RZBarLimit.transform.localScale = new Vector3(RRotationLimit, 0.6f, RRotationLimit);
+
+            LYBarLimit.transform.Rotate(new Vector3(0f, 90f, 0f), Space.Self);
+            LZBarLimit.transform.Rotate(new Vector3(90f, 0f, 0f), Space.Self);
+            RYBarLimit.transform.Rotate(new Vector3(0f, 90f, 0f), Space.Self);
+            RZBarLimit.transform.Rotate(new Vector3(90f, 0f, 0f), Space.Self);
+
+            LYBarLimit.GetComponent<Renderer>().material.shader = Shader.Find("Universal Render Pipeline/Lit");
+            LZBarLimit.GetComponent<Renderer>().material.shader = Shader.Find("Universal Render Pipeline/Lit");
+            RYBarLimit.GetComponent<Renderer>().material.shader = Shader.Find("Universal Render Pipeline/Lit");
+            RZBarLimit.GetComponent<Renderer>().material.shader = Shader.Find("Universal Render Pipeline/Lit");
+
+            LYBarLimit.GetComponent<Renderer>().material.color = green1;
+            LZBarLimit.GetComponent<Renderer>().material.color = blue1;
+            RYBarLimit.GetComponent<Renderer>().material.color = green1;
+            RZBarLimit.GetComponent<Renderer>().material.color = blue1;
+
+            LRotateLimit.transform.position = poseGhost.leftHand.position + new Vector3(-0.3f, 0.15f, -0.3f);
+            RRotateLimit.transform.position = poseGhost.rightHand.position + new Vector3(-0.3f, 0.15f, -0.3f);
+            LRotate.transform.position = poseGhost.leftHand.position + new Vector3(-0.3f, 0.15f, -0.3f);
+            RRotate.transform.position = poseGhost.rightHand.position + new Vector3(-0.3f, 0.15f, -0.3f);
+            if (poseGhost.leftHand.rotation.eulerAngles.x == poseGhost.CurrentPoseSet.configurations[poseGhost.currentVisualPoseIndex].Pose.leftControllerCondition.DesiredPose.rotation.eulerAngles.x) // if the hands are not mirrored, use the normal map
+            {
+                LCube.transform.localRotation = poseGhost.CurrentPoseSet.configurations[poseGhost.currentVisualPoseIndex].Pose.leftControllerCondition.DesiredPose.rotation;
+                RCube.transform.localRotation = poseGhost.CurrentPoseSet.configurations[poseGhost.currentVisualPoseIndex].Pose.rightControllerCondition.DesiredPose.rotation;
+            }
+            else // they need to be swapped
+            {
+                RCube.transform.localRotation = poseGhost.CurrentPoseSet.configurations[poseGhost.currentVisualPoseIndex].Pose.leftControllerCondition.DesiredPose.rotation;
+                LCube.transform.localRotation = poseGhost.CurrentPoseSet.configurations[poseGhost.currentVisualPoseIndex].Pose.rightControllerCondition.DesiredPose.rotation;
+            }
+            LRotateLimit.transform.rotation = LCube.transform.rotation;
+            RRotateLimit.transform.rotation = RCube.transform.rotation;
+            //MelonLogger.Msg("gyros done");
+            yield break;
         }
     }
 }


### PR DESCRIPTION
- Put hitbox creation into a coroutine to pause until the pose ghost has moved to the new pose
- Replaced references to poseGhost.poseGhostVisuals.transform with poseGhost.bodyRenderer.transform.parent
- Replaced poseGhost.showCurrentPoseData with poseGhost.CurrentPoseSet.configurations[poseGhost.currentVisualPoseIndex].Pose
- Updated Calls.GameObjects references to match with the latest version of RumbleModdingAPI